### PR TITLE
Add flags to disable system endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add the following to your Claude Desktop configuration file:
   "mcpServers": {
     "neurelo-connect": {
       "command": "npx",
-      "args": ["tsx", "REPOSITORY_ROOT/src/main.ts"],
+      "args": ["tsx", "REPOSITORY_ROOT/src/main.ts", "start"],
       "cwd": "REPOSITORY_ROOT",
       "env": {
         "ENGINE_API_KEY": "YOUR_ENGINE_API_KEY",

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ This lets you use Claude Desktop, or any MCP Client, to use natural language to 
     - `query` (string): The SQL query to execute
 - Dynamic endpoint tools - Additional tools are automatically generated based on your endpoint metadata
 
+## Configuration Options
+
+- `--disable-tools <tools>` - Comma-separated list of tool names to disable. For example: `--disable-tools raw_query,system_list_databases` will disable the raw query and database listing tools. You can also disable any defined queries by including their tool names in this list.
+
 # Development
 
 ## Development with the MCP inspector

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neurelo/connect-mcp",
-  "version": "0.0.2-12",
+  "version": "0.0.2-13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neurelo/connect-mcp",
-      "version": "0.0.2-12",
+      "version": "0.0.2-13",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.4.1",
         "axios": "^1.7.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neurelo/connect-mcp",
-  "version": "0.0.2-13",
+  "version": "0.0.2-14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neurelo/connect-mcp",
-      "version": "0.0.2-13",
+      "version": "0.0.2-14",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.4.1",
         "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurelo/connect-mcp",
-  "version": "0.0.2-13",
+  "version": "0.0.2-14",
   "description": "Neurelo Connect MCP server",
   "repository": "https://github.com/neurelo-connect/neurelo-connect-mcp",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurelo/connect-mcp",
-  "version": "0.0.2-12",
+  "version": "0.0.2-13",
   "description": "Neurelo Connect MCP server",
   "repository": "https://github.com/neurelo-connect/neurelo-connect-mcp",
   "type": "module",

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,7 @@ program
     new Option(
       "--disable-tools <tools>",
       "The comma-separated list of tools to disable.",
-    ).default([]),
+    ),
   )
   .hook("preAction", (thisCommand) => {
     checkNodeVersion();
@@ -112,12 +112,12 @@ program
       }
     }
 
-    // Make sure the disable-tools option is an array if undefined
-    if (options["disableTools"] && !Array.isArray(options["disableTools"])) {
-      stderr.write(
-        "--disable-tools must be a comma-separated list of tool names\n",
-      );
-      process.exit(1);
+    // Make sure the disable-tools option is an array if it's a comma-separated list
+    if (
+      options["disableTools"] &&
+      typeof options["disableTools"] === "string"
+    ) {
+      options["disableTools"] = options["disableTools"].split(",");
     }
   })
   .action((options) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,8 +49,7 @@ export type MCPOptions = {
   testMode?: boolean;
   engineBasePath?: string;
   engineApiKey?: string;
-  disableRawQueryTool?: boolean;
-  disableRawReadonlyTool?: boolean;
+  disableTools?: string[];
 };
 
 program
@@ -94,21 +93,16 @@ program
     ),
   )
   .addOption(
-    new Option("--disable-raw-query-tool", "Disable raw query tool.").default(
-      false,
-    ),
-  )
-  .addOption(
     new Option(
-      "--disable-raw-readonly-tool",
-      "Disable raw readonly tool.",
-    ).default(false),
+      "--disable-tools <tools>",
+      "The comma-separated list of tools to disable.",
+    ).default([]),
   )
   .hook("preAction", (thisCommand) => {
     checkNodeVersion();
+    const options = thisCommand.optsWithGlobals();
 
     // Only require engine options if not in test mode
-    const options = thisCommand.optsWithGlobals();
     if (!options["testMode"]) {
       if (!(options["engineBasePath"] && options["engineApiKey"])) {
         stderr.write(
@@ -116,6 +110,14 @@ program
         );
         process.exit(1);
       }
+    }
+
+    // Make sure the disable-tools option is an array if undefined
+    if (options["disableTools"] && !Array.isArray(options["disableTools"])) {
+      stderr.write(
+        "--disable-tools must be a comma-separated list of tool names\n",
+      );
+      process.exit(1);
     }
   })
   .action((options) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,8 @@ export type MCPOptions = {
   testMode?: boolean;
   engineBasePath?: string;
   engineApiKey?: string;
+  disableRawQueryTool?: boolean;
+  disableRawReadonlyTool?: boolean;
 };
 
 program
@@ -90,6 +92,17 @@ program
     new Option("--engine-api-key <key>", "The API key for the engine.").env(
       "ENGINE_API_KEY",
     ),
+  )
+  .addOption(
+    new Option("--disable-raw-query-tool", "Disable raw query tool.").default(
+      false,
+    ),
+  )
+  .addOption(
+    new Option(
+      "--disable-raw-readonly-tool",
+      "Disable raw readonly tool.",
+    ).default(false),
   )
   .hook("preAction", (thisCommand) => {
     checkNodeVersion();


### PR DESCRIPTION
This PR adds the optional `--disable-tools` CLI arg that allows users to disable tools in the MCP server config.